### PR TITLE
Fix zoom to geometry on edit from result

### DIFF
--- a/services/editingservice.js
+++ b/services/editingservice.js
@@ -270,8 +270,6 @@ proto.editResultLayerFeature = function({layer, feature}={}){
         map.getView().setResolution(resolution);
       }
     });
-    // zoom to feature geometry
-    this._mapService.zoomToGeometry(feature.geometry);
   }
   // start toolbox
   toolBox.start({
@@ -282,6 +280,7 @@ proto.editResultLayerFeature = function({layer, feature}={}){
     .then(({features=[]}) => {
       const feature = features.find(feature => feature.getId() == featureId);
       if (feature){
+        feature.getGeometry() && this._mapService.zoomToGeometry(feature.getGeometry());
         toolBox.setSelected(true);
         const session = toolBox.getSession();
         this.setSelectedToolbox(toolBox);

--- a/services/editingservice.js
+++ b/services/editingservice.js
@@ -278,7 +278,12 @@ proto.editResultLayerFeature = function({layer, feature}={}){
     }
   })
     .then(({features=[]}) => {
-      const feature = features.find(feature => feature.getId() == featureId);
+      //const feature = features.find(feature => feature.getId() == featureId);
+      /**
+       *
+       * Need to get feature from Editing layer source because it has a style layer
+       */
+      const feature = toolBox.getLayer().getEditingLayer().getSource().getFeatures().find(feature => feature.getId() == featureId);
       if (feature){
         feature.getGeometry() && this._mapService.zoomToGeometry(feature.getGeometry());
         toolBox.setSelected(true);


### PR DESCRIPTION
When edit feature from result, in case of relation feature as follow image:

![Screenshot from 2023-01-12 17-08-04](https://user-images.githubusercontent.com/1051694/212119639-9a1de216-43db-45e2-aaef-d2d443b2b16e.png)

is rises an javascript error due at type of geometry of the feature.
It also solved a issue related to set select style of current editing feature 