### PR TITLE
Missing not editable pk field when create new feature with Copy Features or Split Features

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "editing",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "description": "",
   "main": "index.js",
   "directories": {

--- a/workflows/steps/tasks/moveelementstask.js
+++ b/workflows/steps/tasks/moveelementstask.js
@@ -76,7 +76,7 @@ proto.run = function(inputs, context) {
     Promise.allSettled(promisesDefaultEvaluation)
       .then(promises => {
         promises.forEach(({status, value:feature}) => {
-          source.addFeature(feature);
+
           /**
            * @todo improve client core to handle this situation on session.pushAdd not copy pk field not editable only
            */
@@ -89,6 +89,9 @@ proto.run = function(inputs, context) {
           if (Object.entries(noteditablefieldsvalues).length) {
             Object.entries(noteditablefieldsvalues).forEach(([field, value]) => newFeature.set(field, value));
           }
+
+          //need to add to editing layer source newFeature
+          source.addFeature(newFeature);
 
           inputs.features.push(newFeature);
         })

--- a/workflows/steps/tasks/splitfeaturetask.js
+++ b/workflows/steps/tasks/splitfeaturetask.js
@@ -114,7 +114,7 @@ proto._handleSplitFeature = async function({feature, inputs, context, splittedGe
       });
 
       feature.setTemporaryId();
-      source.addFeature(feature);
+
       /**
        * * evaluate geometry expression
       */
@@ -138,7 +138,13 @@ proto._handleSplitFeature = async function({feature, inputs, context, splittedGe
         const newFeature = session.pushAdd(layerId, feature);
         Object.entries(noteditablefieldsvalues).forEach(([field, value]) => newFeature.set(field, value));
         newFeatures.push(newFeature);
-      } else newFeatures.push(session.pushAdd(layerId, feature));
+        //need to add features with no editable fields on layers source
+        source.addFeature(newFeature);
+      } else {
+        newFeatures.push(session.pushAdd(layerId, feature));
+        //add feature to source
+        source.addFeature(feature);
+      }
 
     }
     inputs.features.push(feature);


### PR DESCRIPTION
Close #45 

Now **fid** (pk field not editable) is sent to server as feature property

![Screenshot from 2023-07-11 09-41-37](https://github.com/g3w-suite/g3w-client-plugin-editing/assets/1051694/2ea85c37-1387-487a-94d2-85d7a6ac7b1f)
