### PR TITLE
Add support for chain filter option within relation reference widget

### DIFF
--- a/components/Toolbox.vue
+++ b/components/Toolbox.vue
@@ -211,7 +211,7 @@
       /**
        * @returns { boolean } whether current has related layer(s) (aka. layer relations / joins)
        *
-       * @since 3.7.0
+       * @since g3w-client-plugin-editing@v3.7.0
        */
       hasRelations() {
         return this.state.editing.dependencies.length > 0;

--- a/eventbus.js
+++ b/eventbus.js
@@ -1,7 +1,7 @@
 /**
  * @file shared vue instance used to watch object changes or to emit events
  * 
- * @since 3.7.0
+ * @since g3w-client-plugin-editing@v3.7.0
  */
 export const VM = new Vue();
 

--- a/form/editingform.js
+++ b/form/editingform.js
@@ -10,13 +10,15 @@ function EditingFormComponent(options = {}) {
   const EditingService   = require('../services/editingservice');
   const relationsOptions = options.context_inputs || null;
   const layerId          = options.layer.getId();
+  const hasFormStructure = options.layer.getLayerEditingFormStructure(); //@since 3.7.2
   const feature          = (
     relationsOptions &&
     relationsOptions.inputs &&
     relationsOptions.inputs.features &&
     relationsOptions.inputs.features[relationsOptions.inputs.features.length - 1]
   );
-  if (feature) {
+  //handle relations on form only if layer has form structure
+  if (hasFormStructure && feature) {
     (
       feature.isNew()
         ? Promise.resolve()

--- a/form/editingform.js
+++ b/form/editingform.js
@@ -10,57 +10,63 @@ function EditingFormComponent(options = {}) {
   const EditingService   = require('../services/editingservice');
   const relationsOptions = options.context_inputs || null;
   const layerId          = options.layer.getId();
-  const hasFormStructure = options.layer.getLayerEditingFormStructure(); //@since 3.7.2
+  const hasFormStructure = options.layer.getLayerEditingFormStructure(); // @since g3w-client-plugin-editing@v3.7.2
   const feature          = (
     relationsOptions &&
     relationsOptions.inputs &&
     relationsOptions.inputs.features &&
     relationsOptions.inputs.features[relationsOptions.inputs.features.length - 1]
   );
-  //handle relations on form only if layer has form structure
-  if (hasFormStructure && feature) {
-    (
-      feature.isNew()
-        ? Promise.resolve()
-        : EditingService.getLayersDependencyFeatures(layerId, {
-          // @since g3w-client-plugin-editin@v3.7.0
-          relations: options.layer
-            .getRelations()
-            .getArray().filter(r =>
-              (
-                EditingService.getLayerById(r.getChild()) && // child layer is in editing
-                'ONE' !== r.getType()                        // is not a ONE relation (Join 1:1)
-              )
-            ),
-          feature, filterType: 'fid'
-        })
-    ).then(() => {
-      relationsOptions.formEventBus = this.getService().getEventBus();
 
-      const service                 = new EditingFormService(relationsOptions);
-      const RelationComponents      = service.buildRelationComponents();
-      const customFormComponents    = EditingService.getFormComponentsById(layerId);
-
-      // check if add components to add
-      if (customFormComponents.length > 0) {
-        this.addFormComponents(customFormComponents);
-      }
-
-      // add relation component
-      if (RelationComponents.length > 0)  {
-        this.addFormComponents(RelationComponents);
-      }
-
-      // overwrite click on relation handler
-      this.getService().handleRelation = async function({ relation }) {
-        GUI.setLoadingContent(true);
-        await EditingService.setLayerUniqueFieldValues(options.layer.getRelationById(relation.name).getChild());
-        this.setCurrentComponentById(relation.name);
-        GUI.setLoadingContent(false);
-      };
-
-    });
+  // skip relations that doesn't have form structure
+  if (!hasFormStructure || !feature) {
+    return;
   }
+
+  (
+    feature.isNew()
+      ? Promise.resolve()
+      : EditingService.getLayersDependencyFeatures(layerId, {
+        // @since g3w-client-plugin-editin@v3.7.0
+        relations: options.layer
+          .getRelations()
+          .getArray()
+          .filter(r =>
+            (
+              EditingService.getLayerById(r.getChild()) && // child layer is in editing
+              'ONE' !== r.getType()                        // is not a ONE relation (Join 1:1)
+            )
+          ),
+        feature,
+        filterType: 'fid',
+      })
+  ).then(() => {
+    relationsOptions.formEventBus = this.getService().getEventBus();
+
+    const service                 = new EditingFormService(relationsOptions);
+    const RelationComponents      = service.buildRelationComponents();
+    const customFormComponents    = EditingService.getFormComponentsById(layerId);
+
+    // check if add components to add
+    if (customFormComponents.length > 0) {
+      this.addFormComponents(customFormComponents);
+    }
+
+    // add relation component
+    if (RelationComponents.length > 0)  {
+      this.addFormComponents(RelationComponents);
+    }
+
+    // overwrite click on relation handler
+    this.getService().handleRelation = async function({ relation }) {
+      GUI.setLoadingContent(true);
+      await EditingService.setLayerUniqueFieldValues(options.layer.getRelationById(relation.name).getChild());
+      this.setCurrentComponentById(relation.name);
+      GUI.setLoadingContent(false);
+    };
+
+  });
+
 }
 
 inherit(EditingFormComponent, FormComponent);

--- a/services/editingservice.js
+++ b/services/editingservice.js
@@ -1095,6 +1095,7 @@ proto._attachLayerWidgetsEvent = function(layer) {
           loading,
           relation_id,        // @since g3w-client-plugin-editing@v3.7.0
           relation_reference, // @since g3w-client-plugin-editing@v3.7.0
+          filter_fields=[],   // @since 3.72
         } = options;
         const self = this;
         if (!usecompleter) {
@@ -1110,7 +1111,8 @@ proto._attachLayerWidgetsEvent = function(layer) {
                 loading.state = 'loading';
                 field.input.options.values = [];
                 //check if field has a relation reference widget
-                if (relation_reference) {
+                // and no filter fields set
+                if (relation_reference && filter_fields.length === 0) {
                   //get data with fformatter
                   layer.getFilterData({
                     fformatter: field.name

--- a/services/editingservice.js
+++ b/services/editingservice.js
@@ -208,7 +208,7 @@ function EditingService() {
    */
   this._ready = function() {
 
-    // @since 3.7.0
+    // @since g3w-client-plugin-editing@v3.7.0
     this.setRelations1_1FieldsEditable();
 
     // set toolbox colors
@@ -1095,7 +1095,7 @@ proto._attachLayerWidgetsEvent = function(layer) {
           loading,
           relation_id,        // @since g3w-client-plugin-editing@v3.7.0
           relation_reference, // @since g3w-client-plugin-editing@v3.7.0
-          filter_fields=[],   // @since 3.72
+          filter_fields=[],   // @since g3w-client-plugin-editing@v3.7.2
         } = options;
         const self = this;
         if (!usecompleter) {
@@ -2741,7 +2741,7 @@ proto.getExternalLayersWithSameGeometryOfLayer = function(layer) {
  * 
  * @returns (field.key) or (field.value)
  * 
- * @since 3.7.0
+ * @since g3w-client-plugin-editing@v3.7.0
  */
 proto.getFeatureTableFieldValue = function({
   layerId,

--- a/workflows/steps/tasks/openformtask.js
+++ b/workflows/steps/tasks/openformtask.js
@@ -171,7 +171,7 @@ proto._getForm = async function(inputs, context) {
 };
 
 proto._cancelFnc = function(promise, inputs) {
-  return function() {
+  return () => {
     if (!this._isContentChild){
       GUI.setModal(false);
       // fire event cancel form to emit to subscrivers
@@ -295,7 +295,7 @@ proto._saveFeatures = async function({fields, promise, session, inputs}){
 };
 
 proto._saveFnc = function(promise, context, inputs) {
-  return function(fields) {
+  return (fields) => {
     const session = context.session;
     this._saveFeatures({
       fields,
@@ -356,7 +356,7 @@ proto.startForm = async function(options = {}) {
           "plugins.editing.form.buttons.save",
         type: "save",
         class: "btn-success",
-        cbk: this._saveFnc(promise, context, inputs).bind(this)
+        cbk: this._saveFnc(promise, context, inputs)
       },
       {
         id: 'cancel',
@@ -374,7 +374,7 @@ proto.startForm = async function(options = {}) {
             }
           }
         },
-        cbk: this._cancelFnc(promise, inputs).bind(this)
+        cbk: this._cancelFnc(promise, inputs)
       }
     ]
   });


### PR DESCRIPTION
## Depends on: https://github.com/g3w-suite/g3w-client/pull/534

## Demo Project: [water_project.zip](https://github.com/g3w-suite/g3w-client/files/9475387/water_project.zip)

![image](https://github.com/g3w-suite/g3w-client-plugin-editing/assets/9614886/9c6abe67-5ae8-4977-9934-77f701740c17)

## QGIS Configuration: [Relation Reference Widget > Chain Filters](https://docs.qgis.org/3.28/en/docs/user_manual/working_with_vector/vector_properties.html#edit-widgets)

![188070261-feceffd4-31fe-47d5-868e-03d3c2b8f067](https://github.com/g3w-suite/g3w-client-plugin-editing/assets/9614886/f318bb42-9039-4c82-b49a-ad55d5a981dc)

![188072656-28e588c1-1d01-49cb-b2ed-eae74f4fe792](https://github.com/g3w-suite/g3w-client-plugin-editing/assets/9614886/62136e04-e2e7-4975-a829-2cdac5dfb65c)

## List of changes

- handle `fformatter` layer data only if `filter_fields` is not set, closes: [#63](https://github.com/g3w-suite/g3w-client-plugin-editing/issues/63)
- remove `_cancelFnc` and `_saveFnc` functions, closes: [#84](https://github.com/g3w-suite/g3w-client-plugin-editing/issues/84)
