### PR TITLE
Fix editing save all button and disable close editing panel button (x) when at least one layer is in editing

### DIFF
--- a/components/Editing.vue
+++ b/components/Editing.vue
@@ -185,7 +185,7 @@
         if (toolbox.state.editing.history.commit) {
           this.$options.service
             .commit()
-            .always(() => toolbox.stop());
+            .always(() => toolbox.stop().then(() => this.layersInEditing--));
         } else {
           toolbox
             .stop()

--- a/components/Editing.vue
+++ b/components/Editing.vue
@@ -7,6 +7,8 @@
 
     <bar-loader :loading="saving"/>
 
+    <helpdiv v-if ="layersInEditing > 0" style="font-weight: bold" message="plugins.editing.close_editing_panel.message" />
+
     <!-- OFFLINE MESSAGE -->
     <div
       v-if  = "!appState.online"

--- a/components/Editing.vue
+++ b/components/Editing.vue
@@ -114,7 +114,8 @@
 
     data() {
       return {
-        saving: false, // whether to show loading bar while committing to server (click on save disk icon)  
+        saving: false, // whether to show loading bar while committing to server (click on save disk icon)
+        layersInEditing: 0, //@since 3.8.0 Number of layers in editing
       };
     },
 
@@ -168,7 +169,9 @@
             try      { await this.$options.service.commitDirtyToolBoxes(dirtyId); }
             catch(e) { console.warn(e); }
           }
-          toolbox.start();
+          toolbox
+            .start()
+            .then(() => this.layersInEditing++)
         }
       },
 
@@ -182,7 +185,9 @@
             .commit()
             .always(() => toolbox.stop());
         } else {
-          toolbox.stop();
+          toolbox
+            .stop()
+            .then(() => this.layersInEditing--)
         }
       },
 
@@ -332,6 +337,13 @@
       canCommit(bool) {
         this.$options.service.registerLeavePage(bool);
       },
+      /**
+       * @since 3.8.0
+       * @param { Number } n number of layer in editing
+       */
+      layersInEditing(n) {
+        document.getElementsByClassName('close-pane-button')[0].classList[0 === n ? 'remove' : 'add']('g3w-disabled');
+      }
 
     },
 

--- a/components/Editing.vue
+++ b/components/Editing.vue
@@ -164,7 +164,7 @@
           if (dirtyId) {
             //if there is a layer with not saved/committed changes ask before get start toolbox
             //otherwise changes made on relation layers are not sync with current database state
-            //example Join 1:1 fields
+            //example Joins 1:1 fields
             try      { await this.$options.service.commitDirtyToolBoxes(dirtyId); }
             catch(e) { console.warn(e); }
           }
@@ -247,7 +247,7 @@
           selected.clearMessage();
         }
 
-        // set current selected toolbox to true
+        // set the current selected toolbox to true
         toolbox.setSelected(true);
 
         this.state.toolboxselected = toolbox;

--- a/components/FormRelation.vue
+++ b/components/FormRelation.vue
@@ -4,9 +4,10 @@
 
 <template>
     <div
-      v-if  = "active"
+      v-disabled  = "loading"
       style = "margin-bottom: 5px;"
     >
+      <bar-loader :loading="loading"/>
 
       <!-- RELATION TITLE -->
       <div
@@ -277,10 +278,10 @@ flex-direction: column
 
     methods: {
       /**
-       * Resize method to adapt table when window is resized
+       * Resize method to adapt table when a window is resized
        */
       resize() {
-        // skip when relation form is disabled (or hidden) 
+        // skip when a relation form is disabled (or hidden)
         if (!(this.active && 'none' !== this.$el.style.display)) {
           return;
         }

--- a/components/SaveAll.vue
+++ b/components/SaveAll.vue
@@ -64,9 +64,13 @@
     },
 
     computed: {
-
+      /**
+       * Set disabling save all button when it is not enabled (a case of parent form is not valid,
+       * or when current form i not valid or valid but not updated)
+       * @return {boolean}
+       */
       disabled() {
-        return !this.enabled && (!this.valid || !this.update);
+        return !this.enabled || !(this.valid && this.update);
       },
 
     },
@@ -97,7 +101,9 @@
     },
 
     created() {
-     //In case of workflow task are less than 2
+      //set enabled to true as default value;
+      this.enabled = true;
+      //In the case of a workflow task are less than 2
       if (WorkflowsStack.getLength() < 2) {
         return;
       }

--- a/config/i18n/de.js
+++ b/config/i18n/de.js
@@ -1,4 +1,7 @@
 export default {
+  close_editing_panel: {
+    message: "To close editing form need to exit from editing layer"
+  },
   errors: {
     no_layers: "Es tritt ein Fehler auf. Es ist nicht möglich, Layer zu bearbeiten",
     some_layers: "Es tritt ein Fehler auf: Es ist nicht möglich, einige Layer zu bearbeiten"

--- a/config/i18n/en.js
+++ b/config/i18n/en.js
@@ -1,4 +1,7 @@
 export default {
+  close_editing_panel: {
+    message: "To close editing form need to exit from editing layer"
+  },
   errors: {
     no_layers: "An error occurs. It's no possible to edit layers",
     some_layers: "An error occurs: It's no possible to edit some layers"

--- a/config/i18n/fi.js
+++ b/config/i18n/fi.js
@@ -1,4 +1,7 @@
 export default {
+  close_editing_panel: {
+    message: "To close editing form need to exit from editing layer"
+  },
   errors: {
     no_layers: "Tapahtui virhe. Tasoja ei ole mahdollista muokata.",
     some_layers: "Tapahtui virhe. Jotkin tasot eivät ole muokattavissa."

--- a/config/i18n/fr.js
+++ b/config/i18n/fr.js
@@ -1,4 +1,7 @@
 export default {
+  close_editing_panel: {
+    message: "To close editing form need to exit from editing layer"
+  },
   errors: {
     no_layers: "Une erreur s'est produite lors du chargement des layers dans l'édition.",
     some_layers: "Une erreur s'est produite lors du chargement de certaines layers dans l'édition."

--- a/config/i18n/it.js
+++ b/config/i18n/it.js
@@ -1,4 +1,7 @@
 export default {
+  close_editing_panel: {
+    message: "Uscire dall'editing per chiudere il form"
+  },
   errors: {
     no_layers: "Si è verificato un errore nel caricamento dei layers in editing.",
     some_layers: "Si è verificato un errore nel caricamento di alcuni layers in editing"

--- a/config/i18n/ro.js
+++ b/config/i18n/ro.js
@@ -1,4 +1,7 @@
 export default  {
+  close_editing_panel: {
+    message: "To close editing form need to exit from editing layer"
+  },
   errors: {
     no_layers: "Avem o eroare. Straturile nu sunt editabile",
     some_layers: "Avem o eroare: Anumite straturi nu se pot edita"

--- a/config/i18n/se.js
+++ b/config/i18n/se.js
@@ -1,4 +1,7 @@
 export default {
+  close_editing_panel: {
+    message: "To close editing form need to exit from editing layer"
+  },
   errors: {
     no_layers: "Ett fel uppstod. Nivåerna kan inte redigeras.",
     some_layers: "Ett fel uppstod. Vissa nivåer kan inte redigeras."

--- a/services/editingservice.js
+++ b/services/editingservice.js
@@ -2345,7 +2345,7 @@ proto.commit = function({
         },
         id: OFFLINE_ITEMS.CHANGES
       })
-        .then(() =>{
+        .then(() => {
           GUI.showUserMessage({
             type: 'success',
             message: "plugins.editing.messages.saved_local",


### PR DESCRIPTION
Close https://github.com/g3w-suite/g3w-client-plugin-editing/issues/104

**Before**

Parent feature has not a valid form (some mandatory field are not filled)

![Screenshot from 2024-03-25 15-51-03](https://github.com/g3w-suite/g3w-client-plugin-editing/assets/1051694/0f51ed16-4937-4a2c-aa28-d2e67bcfbbf8)

If try to add a relation feature, save all button is enabled but it is **wrong**:

![Screenshot from 2024-03-25 15-52-25](https://github.com/g3w-suite/g3w-client-plugin-editing/assets/1051694/5954f91d-0577-49e9-80e6-886055040cd8)

**After**

Save all button on relation feature is disabled because parent form is not valid

![Screenshot from 2024-03-25 15-59-35](https://github.com/g3w-suite/g3w-client-plugin-editing/assets/1051694/6928caa4-7ce1-49e0-925d-32a6a6da7d37)
