### PR TITLE
Can't close editing panel when edit feature from result panel

### DIFF
--- a/components/Toolbox.vue
+++ b/components/Toolbox.vue
@@ -346,10 +346,17 @@
 
     watch: {
 
-      async'state.activetool'(activetool) {
+      async 'state.activetool'(activetool) {
         await this.$nextTick();
         this.currenttoolhelpmessage = activetool && activetool.getHelpMessage();
       },
+      /**
+       * Method to watch toolbox in editing state
+       * @param bool
+       */
+      'state.editing.on'(bool) {
+        this.$emit('on-editing', bool);
+      }
 
     },
 


### PR DESCRIPTION
**Before**


1. Click on edit feature

![Screenshot from 2024-03-29 16-16-03](https://github.com/g3w-suite/g3w-client-plugin-editing/assets/1051694/417e9b93-8538-42c2-b70a-0023b0326048)

2. Edit feature
3. Stop editing from toolbox

![Screenshot from 2024-03-29 16-19-13](https://github.com/g3w-suite/g3w-client-plugin-editing/assets/1051694/37fed1cd-6693-47ba-99c6-356d22dc21a1)

Close Editing panel button (x) is disabled (can't close editing panel)

![Screenshot from 2024-03-29 16-20-01](https://github.com/g3w-suite/g3w-client-plugin-editing/assets/1051694/c8153657-542f-42e1-b788-10d042e8f51d)


**After**

After edit feature and before save changese, close editing panel is disabled and a message is show.

![Screenshot from 2024-03-29 16-24-13](https://github.com/g3w-suite/g3w-client-plugin-editing/assets/1051694/f74c14a7-b722-46e4-aa15-ee8854d87b36)

After stop editing toolbox

![Screenshot from 2024-03-29 16-19-13](https://github.com/g3w-suite/g3w-client-plugin-editing/assets/1051694/37fed1cd-6693-47ba-99c6-356d22dc21a1)

Close editing panel button (x) is enabled and can be close editing panel

![Screenshot from 2024-03-29 16-27-54](https://github.com/g3w-suite/g3w-client-plugin-editing/assets/1051694/36338793-ce38-4373-959e-423823631267)

