### PR TITLE
:sparkles: Add copy feature in relations tables tools

### DIFF
--- a/components/FormRelation.vue
+++ b/components/FormRelation.vue
@@ -258,6 +258,7 @@
 
   import { Workflow }                                     from '../g3wsdk/workflow/workflow';
   import { Step }                                         from '../g3wsdk/workflow/step';
+  import { cloneFeature }                                 from '../utils/cloneFeature';
   import { setAndUnsetSelectedFeaturesStyle }             from '../utils/setAndUnsetSelectedFeaturesStyle';
   import { promisify, $promisify }                        from '../utils/promisify';
   import { getRelationFieldsFromRelation }                from '../utils/getRelationFieldsFromRelation';
@@ -633,6 +634,18 @@
             type: 'editfeatureattributes',
           },
 
+          // @since 3.9.0 copy feature
+          this.capabilities.includes('add_feature') && {
+            state: Vue.observable({
+              icon:   'pasteFeaturesFromOtherLayers.png',
+              id:     `${id}_copyfeature`,
+              name:   'editing.tools.copy',
+              enabled: true,
+              active:  false,
+            }),
+            type: 'addfeature',
+          },
+
           // delete feature
           this.capabilities.includes('delete_feature') && {
             state: Vue.observable({
@@ -702,6 +715,45 @@
           const relationfeature = this.getLayer().getEditingSource().getFeatureById(relation.id);
           const selectStyle     = is_vector && SELECTED_STYLES[this.getLayer().getGeometryType()]; // get selected vector style
           const options         = this._createWorkflowOptions({ features: [relationfeature] });
+
+          //@since 3.9.0 COPY FEATURE FROM ATTRIBUTE TABLE LAYER
+          if ('copyfeature' === toolId) {
+            await (
+              new Promise(async (resolve, reject) => {
+                //replace current feature with clone
+                options.inputs.features = [cloneFeature(relationfeature, this.getLayer())];
+                // //need to sett original layer
+                // options.inputs.layer    = CatalogLayersStoresRegistry.getLayerById(this._relationLayerId);
+                const workflow = new Workflow({
+                  type: 'addtablefeature',
+                  steps: [
+                    new Step({ help: 'editing.steps.help.new', run: addTableFeature }),
+                    new OpenFormStep(),
+                  ],
+                });
+                try {
+                  const outputs = await promisify(workflow.start(options));
+                  const feature = outputs.features[outputs.features.length - 1];
+                  this.relations.push({ id: feature.getId(), fields: this.getLayer().getFieldsWithValues(feature, { relation: true }) });
+                  resolve(feature);
+                } catch(e) {
+                  console.warn(e);
+                  //in case of seva all click
+                  if (options.inputs && options.inputs.relationFeatures) {
+                    this.relations.push(
+                      ...(options.inputs.relationFeatures.newFeatures || []).map(f => ({ id: f.getId(), fields: this.getLayer().getFieldsWithValues(f, { relation: true }) }))
+                    )
+                  }
+                  reject(e);
+
+                } finally {
+                  workflow.stop();
+                  relationtool.state.active = false;
+
+                }
+              })
+            );
+          }
 
           // DELETE FEATURE RELATION
           if ('deletefeature' === toolId) {

--- a/components/FormRelation.vue
+++ b/components/FormRelation.vue
@@ -634,8 +634,8 @@
             type: 'editfeatureattributes',
           },
 
-          // @since 3.9.0 copy feature
-          this.capabilities.includes('add_feature') && {
+          // @since 3.9.0 copy featureonly for table layer
+          Layer.LayerTypes.TABLE === this._layerType && this.capabilities.includes('add_feature') && {
             state: Vue.observable({
               icon:   'pasteFeaturesFromOtherLayers.png',
               id:     `${id}_copyfeature`,

--- a/utils/addTableFeature.js
+++ b/utils/addTableFeature.js
@@ -7,7 +7,7 @@ import { $promisify } from './promisify';
  * @since g3w-client-plugin-editing@v3.8.0
  */
 export function addTableFeature(inputs, context) {
-  const feature = inputs.features.length > 0 ? inputs.features[inputs.features.length -1 ] : inputs.layer.createNewFeature();
+  const feature = inputs.features.length > 0 ? inputs.features[inputs.features.length - 1 ] : inputs.layer.createNewFeature();
 
   feature.setTemporaryId();
 


### PR DESCRIPTION
Closes: #138 

Add copy feature tool

![Screenshot from 2024-11-22 15-32-56](https://github.com/user-attachments/assets/8edf2e47-5743-4b95-9d04-286729a80958)
