### PR TITLE
🐛 Filter only editable relations that are visible to current user (ref: toolbox child layers)

### DIFF
--- a/toolboxes/toolbox.js
+++ b/toolboxes/toolbox.js
@@ -87,14 +87,13 @@ export class ToolBox extends G3WObject {
     const is_table           = Layer.LayerTypes.TABLE === layer.getType();
     const isMultiGeometry    = geometryType && Geometry.isMultiGeometry(geometryType);
     const iconGeometry       = is_vector && (is_point ? 'Point' : is_line ? 'Line' : 'Polygon');
-    //@since 3.9.0 Check if layer has relation layers editable
+    //@since 3.9.0 Check if layer has "relation layers" that are editable
     const editable_relations = layer.getRelations().getArray()
-                              .filter(relation => {
-                                const l = CatalogLayersStoresRegistry.getLayerById(getRelationId({ layerId: layer.getId(), relation }));
-                                //@since 3.9.1 Fix in case child layer is not visible on TOC (set view permission from admin)
-                                return l && l.isEditable();
-                              })
-                              .map(r => r);
+      .filter(relation => {
+        const l = CatalogLayersStoresRegistry.getLayerById(getRelationId({ layerId: layer.getId(), relation }));
+        return l && l.isEditable();
+      })
+      .map(r => r);
     this._start       = false;
 
     /** constraint loading features to a filter set */

--- a/toolboxes/toolbox.js
+++ b/toolboxes/toolbox.js
@@ -91,7 +91,8 @@ export class ToolBox extends G3WObject {
     const editable_relations = layer.getRelations().getArray()
                               .filter(relation => {
                                 const l = CatalogLayersStoresRegistry.getLayerById(getRelationId({ layerId: layer.getId(), relation }));
-                                return l.isEditable();
+                                //@since 3.9.1 Fix in case child layer is not visible on TOC (set view permission from admin)
+                                return l && l.isEditable();
                               })
                               .map(r => r);
     this._start       = false;

--- a/toolboxes/toolbox.js
+++ b/toolboxes/toolbox.js
@@ -92,8 +92,8 @@ export class ToolBox extends G3WObject {
       .filter(relation => {
         const l = CatalogLayersStoresRegistry.getLayerById(getRelationId({ layerId: layer.getId(), relation }));
         return l && l.isEditable();
-      })
-      .map(r => r);
+      });
+         
     this._start       = false;
 
     /** constraint loading features to a filter set */


### PR DESCRIPTION
In case admin set a layer not visible for a specific user:

![Screenshot_20250224_093214](https://github.com/user-attachments/assets/eba78d5f-dc07-4cda-a8a4-9590745b7ae9)


and this layer is in relation with an editable layer (father), when try to load a editing plugin, we get this error:

![Screenshot_20250224_093319](https://github.com/user-attachments/assets/cfdfb1f0-f5a1-4c40-b54d-6443c3e8a1d1)


