### PR TITLE
Avoid to call server request on relation reference widget on relation layer

### DIFF
--- a/components/FormRelation.vue
+++ b/components/FormRelation.vue
@@ -159,7 +159,7 @@
         v-disabled = "disabled"
       >
         <table
-          v-if  = "relationsLength > 0 && !update"
+          v-if  = "relationsLength > 0"
           ref   = "relationTable"
           class = "table g3wform-relation-table table-striped nowrap"
         >

--- a/index.js
+++ b/index.js
@@ -224,7 +224,7 @@ new (class extends Plugin {
         .getEditingFields()
         .filter(field => field.input && 'select_autocomplete' === field.input.type && !field.input.options.filter_expression && !field.input.options.usecompleter)
         /** @TODO need to avoid to call the same fnc to same event many times to avoid waste server request time */
-        .forEach(field => ['start-editing', 'show-relation-editing'].forEach(type => {
+        .forEach(field => ['start-editing'].forEach(type => {
           const id                    = layer.getId();
           this.state.events[type][id] = this.state.events[type][id] || [];
 

--- a/utils/setLayerUniqueFieldValues.js
+++ b/utils/setLayerUniqueFieldValues.js
@@ -1,5 +1,3 @@
-const { CatalogLayersStoresRegistry } = g3wsdk.core.catalog;
-
 /**
  * ORIGINAL SOURCE: g3w-client-plugin-editing/services/editingservice.js@v3.7.8
  * Method to get unique values of unique input values from server
@@ -17,6 +15,14 @@ export async function setLayerUniqueFieldValues(layerId) {
   const service = g3wsdk.core.plugin.PluginsRegistry.getPlugin('editing'); //get editing service
   await new Promise((resolve, reject) => {
     const layer = g3wsdk.core.plugin.PluginsRegistry.getPlugin('editing').getLayerById(layerId);
+    const fields = Object.values(layer
+      .getEditingFields()
+      //filter field that is unique and not yet set unique values
+      .filter(f => !(f.pk && false === f.editable) && ('unique' === f.input.type || f.validate.unique)));
+    if (0 === fields.length) {
+      resolve();
+      return;
+    }
     //get all values for unique field
     layer.getWidgetData({
       type: 'unique',


### PR DESCRIPTION
We found a wasting time request for a widget **relation reference** in case of start editing a relation feature.
Need to use to get parent data relation fields reference only when edit layer in relation direct.

Project https://dev.g3wsuite.it/en/map/g3w-suite-demo/qdjango/97/

![Screenshot_20250430_174937](https://github.com/user-attachments/assets/3ffa5e87-d4b0-48dd-84e3-616965404b20)

**Maintenance works layer editing fields**

![Screenshot_20250430_175028](https://github.com/user-attachments/assets/3c12f816-2539-424e-93b2-59867eb19446)
