### PR TITLE
Feature locked warning not shown to end user when an edit starts from query result

### DIFF
--- a/i18n/de.js
+++ b/i18n/de.js
@@ -96,6 +96,7 @@ export default {
   },
   messages: {
     featureslockbyotheruser: "Einige Geometrien/Datensätze können nicht bearbeitet werden, da sie von anderen Benutzern bearbeitet werden",
+    featurelockbyotheruser: "Die Geometrie/der Datensatz kann nicht bearbeitet werden, da er von anderen Benutzern bearbeitet wird",
     splitted: "Getrennt",
     nosplittedfeature: "Feature nicht getrennt",
     press_esc: "Mit ESC zurück",

--- a/i18n/en.js
+++ b/i18n/en.js
@@ -101,6 +101,7 @@ export default {
   },
   messages: {
     featureslockbyotheruser: "Some geometries/records are not editable because in editing by other user",
+    featurelockbyotheruser: "The geometry/record is not editable because in editing by other user",
     splitted: "Splitted",
     nosplittedfeature: "Feature not spitted",
     press_esc: "Press ESC to back",

--- a/i18n/fi.js
+++ b/i18n/fi.js
@@ -95,7 +95,8 @@ export default {
     next: "Seuraava",
   },
   messages: {
-    featureslockbyotheruser: "Some features are locked by another user",
+    featureslockbyotheruser: "Some geometries/records are not editable because in editing by other user",
+    featurelockbyotheruser: "The geometry/record is not editable because in editing by other user",
     splitted: "Jaettu",
     nosplittedfeature: "Ominaisuutta ei jaettu",
     press_esc: "Paina ESC palataksesi",

--- a/i18n/fr.js
+++ b/i18n/fr.js
@@ -96,6 +96,7 @@ export default {
   },
   messages: {
     featureslockbyotheruser: "Certaines géométries/enregistrements ne sont pas modifiables car ils ont été modifiés par un autre utilisateur",
+    featurelockbyotheruser: "La géométrie/l'enregistrement n'est pas modifiable car il a été modifié par un autre utilisateur",
     splitted: "Fonctionnalité(s) divisé(es)",
     nosplittedfeature: "La (les) fonctionnalité(s) n’a (n'ont) pas été divisé(es)",
     press_esc: "Appuyez sur ESC pour revenir",

--- a/i18n/it.js
+++ b/i18n/it.js
@@ -102,6 +102,7 @@ export default {
   },
   messages: {
     featureslockbyotheruser: "Ci sono alcune geometrie/records non editabili perchè in modifica da altri utenti",
+    featurelockbyotheruser: "La geometria/record non editabile perchè in modifica da altri utenti",
     splitted: "Feature(s) splittata(e)",
     nosplittedfeature: "La(e) feature(s) non è stata splittata",
     press_esc: "Premi ESC per tornare indietro",

--- a/i18n/pl.js
+++ b/i18n/pl.js
@@ -92,6 +92,7 @@ export default {
   },
   messages: {
     featureslockbyotheruser: "Some geometries/records are not editable because in editing by other user",
+    featurelockbyotheruser: "The geometry/record is not editable because in editing by other user",
     splitted: "Splitted",
     nosplittedfeature: "Feature not spitted",
     press_esc: "Press ESC to back",

--- a/i18n/ro.js
+++ b/i18n/ro.js
@@ -96,6 +96,7 @@ export default  {
   },
   messages: {
     featureslockbyotheruser: "Unele geometrii/înregistrări nu sunt editabile deoarece sunt editate de către alt utilizator",
+    featurelockbyotheruser: "Geometria/înregistrarea nu este editabilă deoarece este editată de un alt utilizator",
     splitted: "Divizat",
     nosplittedfeature: "Entitate nedivizată",
     press_esc: "ESC pentru înapoi",

--- a/i18n/se.js
+++ b/i18n/se.js
@@ -96,6 +96,7 @@ export default {
   },
   messages: {
     featureslockbyotheruser: "Jotkut geometriat/tietueet eivät ole muokattavissa, koska muut käyttäjät muokkaavat niitä",
+    featurelockbyotheruser: "Geometriaa/tietuetta ei voi muokata, koska muut käyttäjät muokkaavat sitä parhaillaan",
     splitted: "Uppdelad",
     nosplittedfeature: "Egenskapen har inte delats upp",
     press_esc: "Tryck ESC för att gå tillbaka",

--- a/i18n/uk.js
+++ b/i18n/uk.js
@@ -98,6 +98,7 @@ export default {
   },
   messages: {
     featureslockbyotheruser: "Частина об'єктів/записів редагується іншим користувачем і недоступна для змін",
+    featurelockbyotheruser: "Об'єкт/запис редагується іншим користувачем і недоступний для редагування",
     splitted: "Розділено",
     nosplittedfeature: "Не розділено",
     press_esc: "Натисність ESC щоб повернутися",

--- a/index.js
+++ b/index.js
@@ -409,8 +409,19 @@ new (class extends Plugin {
         const features = is_vector ? source.getFeatures() : source.readFeatures();
         const feature  = features.find(f => fid == f.getId());
 
-        // skip when not feature is get from server
-        if (!feature) { return }
+        // skip when not feature (ex. locked feature) is get from server
+        if (!feature) { 
+          //stop service
+          this.stop();
+          //hide editing panel
+          this.hideEditingPanel();
+          //show user message
+          GUI.showUserMessage({
+            type:     'warning',
+            message:  'plugins.editing.messages.featureslockbyotheruser',
+          });
+          return;
+        }
 
         const geom = feature.getGeometry();
 
@@ -502,7 +513,8 @@ new (class extends Plugin {
         console.warn(e);
         session.rollback();
       } finally {
-        w.stop();
+        //In case of locked feature, w (workflow) is not defined
+        w && w.stop();
       }
     });
 

--- a/index.js
+++ b/index.js
@@ -418,7 +418,7 @@ new (class extends Plugin {
           //show user message
           GUI.showUserMessage({
             type:     'warning',
-            message:  'plugins.editing.messages.featureslockbyotheruser',
+            message:  'plugins.editing.messages.featurelockbyotheruser',
           });
           return;
         }


### PR DESCRIPTION
## Before
User try to edit a feature from query result content


<img width="527" height="631" alt="Screenshot_20250813_090758" src="https://github.com/user-attachments/assets/4638b289-e0c6-497c-b9c6-83986c80aebb" />

and feature is locked by another user

Edit panel is open, but no feature is loaded from server and ready to edit: user don't understand what happen.

<img width="1211" height="604" alt="Screenshot_20250813_090935" src="https://github.com/user-attachments/assets/940208e1-5756-4bfd-b391-b776530fba29" />

## After
Edit panel is not open, and a warning message is show to user

<img width="1263" height="704" alt="Screenshot_20250813_091119" src="https://github.com/user-attachments/assets/c879c7d3-29f7-4318-8bdf-38e9776ab026" />
