### PR TITLE
Handle modal map on change resolution when editing Form is open

### DIFF
--- a/components/Editing.vue
+++ b/components/Editing.vue
@@ -215,13 +215,20 @@
           console.warn(e);
         }
 
-        await toolbox.stop();
+        //Take in account an error
+        try {
+          await toolbox.stop();
+        } catch(e) {
+          console.warn(e);
+        }
+        
 
         // re-enable query map control
         const control = undefined === this.service.getToolBoxes().find(t => t.state.editing.on) && GUI.getService('map').getMapControlByType({ type: 'query' });
         if (control && !control.isToggled()) {
           control.toggle();
         }
+        
       },
 
       /**

--- a/index.js
+++ b/index.js
@@ -220,7 +220,7 @@ new (class extends Plugin {
       //@since 4.0.1 set fields based on layer editing style
       if (layer.config.editing.layer_style) {
         try {
-          const response = await (XHR.get({url:    layer.getUrl('config'),params: { style: layer.config.editing.layer_style }}));
+          const response = await (XHR.get({ url: layer.getUrl('config'), params: { style: layer.config.editing.layer_style } }));
           layer.config.editing.fields = response?.vector?.fields || [];
         } catch(e) {
           console.warn(e);

--- a/toolboxes/toolbox.js
+++ b/toolboxes/toolbox.js
@@ -1619,6 +1619,13 @@ export class ToolBox extends G3WObject {
       this.startResolve();
     }
 
+    //@since 4.0.1 set modal true in case of openFormStep is running
+    if (this.state.editing.canEdit && this.state.activetool?.op.getRunningStep() instanceof OpenFormStep) {
+      //Check if current interaction is pickLayer 
+      GUI.setModal('picklayer' !== map.getInteractions().item(map.getInteractions().getLength() -1).get('id') );
+      return;
+    }
+
     // async show message because another toolbox can be unselected before
     setTimeout(() => GUI.setModal(!this.state.editing.canEdit, this.messages.constraint.scale));
   }

--- a/toolboxes/toolbox.js
+++ b/toolboxes/toolbox.js
@@ -96,9 +96,9 @@ export class ToolBox extends G3WObject {
         return l && l.isEditable();
       });
          
-    this._start       = false;
+    this._start         = false;
 
-    this._current_style; //@since 4.0.1
+    this._current_style = null; //@since 4.0.1
 
     /** constraint loading features to a filter set */
     this.constraints  = { filter: null, show: null, tools: [] };
@@ -1802,7 +1802,8 @@ export class ToolBox extends G3WObject {
    */
   stop() {
     return $promisify(async () => {
-      if (this.state.layer.config.editing.layer_style && this._current_style !== this.state.layer.config.editing.layer_style) {
+      //@since 4.0.1 check if current style is set (set after start toolbox, otherwise is null)
+      if (this.state.layer.config.editing.layer_style && this._current_style && this._current_style !== this.state.layer.config.editing.layer_style) {
         await CatalogLayersStoresRegistry.getLayerById(this.state.id).changeCurrentStyle(this._current_style);
       }
 
@@ -1872,7 +1873,9 @@ export class ToolBox extends G3WObject {
         console.warn(e);
         return Promise.reject(e);
       } finally {
+        //@since 4.0.1 need to reset to default
         this.state.layer.state.editing.ready = true;
+        this._current_style                  = null;
       }
     });
   }

--- a/toolboxes/toolbox.js
+++ b/toolboxes/toolbox.js
@@ -1852,7 +1852,11 @@ export class ToolBox extends G3WObject {
         return;
       }
 
+      //@since 4.0.1 show Loading toolbox in case of stop (unlock) it takes time
+      // and need to disable toolbox to avoid to click on tools
+      this.state.layer.state.editing.ready = false;
       try {
+        await new Promise((res) => setTimeout(res, 5000))
         await promisify(this._session.stop());
         //set start to false
         this._start           = false
@@ -1868,8 +1872,9 @@ export class ToolBox extends G3WObject {
       } catch(e) {
         console.warn(e);
         return Promise.reject(e);
+      } finally {
+        this.state.layer.state.editing.ready = true;
       }
-
     });
   }
 

--- a/toolboxes/toolbox.js
+++ b/toolboxes/toolbox.js
@@ -1856,7 +1856,6 @@ export class ToolBox extends G3WObject {
       // and need to disable toolbox to avoid to click on tools
       this.state.layer.state.editing.ready = false;
       try {
-        await new Promise((res) => setTimeout(res, 5000))
         await promisify(this._session.stop());
         //set start to false
         this._start           = false

--- a/workflows/index.js
+++ b/workflows/index.js
@@ -970,6 +970,7 @@ export class OpenFormStep extends Step {
     this.layerId = null;
     this._unwatchs.forEach(unwatch => unwatch());
     this._unwatchs = [];
+    this._saveAllError = false;
   }
 
 }

--- a/workflows/index.js
+++ b/workflows/index.js
@@ -464,6 +464,13 @@ export class OpenFormStep extends Step {
     this._saveAll = false === options.saveAll ? options.saveAll : async () => {};
 
     /**
+     * In case of commit error from saveAll methods, need to set it to true to undo changes
+     * @since 4.0.1
+     * 
+     */
+    this._saveAllError = false;
+
+    /**
      * Whether it can handle multi edit features
      */
     this._multi = options.multi || false;
@@ -666,6 +673,12 @@ export class OpenFormStep extends Step {
                 },
               },
               methods: {
+                /**
+                 * Set this._saveAllError 
+                 * @param {@since 4.0.1 } bool 
+                 * @returns 
+                 */
+                setError: (bool = false) => this._saveAllError = bool,
                 async saveAll() {
                   //Set loading content
                   GUI.setLoadingContent(true);
@@ -701,6 +714,8 @@ export class OpenFormStep extends Step {
                   }
                   try {
                     await promisify(g3wsdk.core.plugin.PluginsRegistry.getPlugin('editing').service.commit({ modal: false }));
+                    //set Error to false
+                    this.setError(false);
                     [...Workflow.Stack._workflows]
                       .reverse()
                       .filter(w => "function" === typeof w.getLastStep()._saveAll)
@@ -729,6 +744,8 @@ export class OpenFormStep extends Step {
                           })
                       })
                   } catch(e) {
+                    //setError to true
+                    this.setError(true);
                     console.warn(e);
                   }
                   //set loading content false
@@ -838,6 +855,12 @@ export class OpenFormStep extends Step {
                   }
                 },
                 cbk: () => {
+                  if (this._saveAllError) {
+                    [...Workflow.Stack._workflows]
+                      .reverse()
+                      .filter(w => "function" === typeof w.getLastStep()._saveAll) // need to filter only workflow that
+                      .map( w => w.getLastStep().getContext().session.undo())
+                  }
                   this.fireEvent('cancelform', inputs.features); // fire event cancel form to emit to subscribers
                   reject(inputs);
                 }


### PR DESCRIPTION
Related to https://github.com/g3w-suite/g3w-client/pull/848/commits/252678c4d0be19b8cdb059a95079a888bac7b3ad

## Before

Open Form - Modal (grey color on map) is active

<img width="1381" height="911" alt="Screenshot_20250903_094834" src="https://github.com/user-attachments/assets/b6209de4-bce6-47b3-b6e4-ea3b29217ab4" />

zoom in

<img width="1381" height="911" alt="Screenshot_20250903_094932" src="https://github.com/user-attachments/assets/a21ed698-7d0a-464b-b38b-cd926b2a6f04" />

modal map disappear

## After

<img width="1381" height="911" alt="Screenshot_20250903_095340" src="https://github.com/user-attachments/assets/65504471-2d54-4d02-a436-ae617ac33f00" />

<img width="1381" height="911" alt="Screenshot_20250903_095444" src="https://github.com/user-attachments/assets/291e92d8-86b9-4862-9f8e-bc74e002b4ae" />

