### PR TITLE
🐛 Incorrect handling of editing tools when editing capabilites are reduced

### DIFF
--- a/components/FormRelation.vue
+++ b/components/FormRelation.vue
@@ -67,7 +67,7 @@
 
           <!-- ADD FEATURE -->
           <span
-            v-if                      = "capabilities.includes('add_feature')"
+            v-if                      = "rcapabilities.includes('add_feature')"
             v-t-tooltip:bottom.create = "'plugins.editing.form.relations.tooltips.add_relation'"
             @click.stop               = "show_add_link ? addRelationAndLink() : null"
             class                     = "g3w-icon add-link pull-right"
@@ -1309,6 +1309,8 @@
       g3wsdk.core.plugin.PluginsRegistry.getPlugin('editing').on('commit', this.onCommit);
 
       this.isVectorRelation = Layer.LayerTypes.VECTOR === relationLayer.getType();
+      /** @since 4.0.2 add relation capabilities */ 
+      this.rcapabilities    = relationLayer.state.editing?.capabilities || [];
 
       // vector relation → get all layers with the same geometry
       if (this.isVectorRelation) {

--- a/toolboxes/toolbox.js
+++ b/toolboxes/toolbox.js
@@ -1417,7 +1417,8 @@ export class ToolBox extends G3WObject {
           }),
         },
         // Edit Table feature (alphanumerical layer - No geometry)
-        is_table && capabilities.includes('delete_feature') && capabilities.includes('change_attr_feature') && {
+        // Check capabiliti
+        is_table && (capabilities.includes('delete_feature') || capabilities.includes('change_attr_feature')) && {
           id:   'edittable',
           type: ['delete_feature', 'change_attr_feature'],
           name: "editing.tools.update_feature",


### PR DESCRIPTION
## Closes #170 

## After
No add relation feature is show


<img width="673" height="275" alt="Screenshot_20250922_094601" src="https://github.com/user-attachments/assets/892d8d06-1b9d-46c3-8fc6-b59d66fd342e" />

Show only edit feature 

<img width="413" height="295" alt="Screenshot_20250922_094646" src="https://github.com/user-attachments/assets/7a36b41b-79cb-40d6-b730-80b21f3d4e55" />
