### PR TITLE
Fix undefined property `length` when saving changes (`Changes.vue` modal)

### DIFF
--- a/index.js
+++ b/index.js
@@ -980,7 +980,7 @@ new (class extends Plugin {
                   layer,
                   message: (new (Vue.extend(require('./components/Changes.vue').default))({
                     propsData: {
-                      commits: commitItems,
+                      commits: { ...commitItems },
                       layer
                     }})).$mount().$el,
                 }


### PR DESCRIPTION
<img width="1124" height="679" alt="Screenshot_20251003_140708" src="https://github.com/user-attachments/assets/23c31918-09da-4bd5-a1c1-e7bce6964649" />

We get and error

<img width="643" height="320" alt="Screenshot_20251003_140742" src="https://github.com/user-attachments/assets/7c474277-704d-47d1-8642-f9774719faa3" />
