### PR TITLE
🐛 Error on save feature with geometry null

### DIFF
--- a/toolboxes/toolbox.js
+++ b/toolboxes/toolbox.js
@@ -2925,9 +2925,15 @@ export class ToolBox extends G3WObject {
             }
             return;
           }
+          /**
+           * @since 4.0.3 in case of geometry layer with feature with geometry null,
+           * need to set geometry undefined to avoit that geometry is added to item properties
+           */
+          if (null === item.getGeometry()) {
+            item.setGeometry(undefined);
+          }
           //convert feature to json ex. {geometry:{type: 'Point'}, properties:{}.....}
           const itemObj = GeoJSONFormat.writeFeatureObject(item);
-          
           //In the case of 3D geometry need to set the same tpe of layer (LineStringMZ...)
 
           /**

--- a/toolboxes/toolbox.js
+++ b/toolboxes/toolbox.js
@@ -2927,7 +2927,7 @@ export class ToolBox extends G3WObject {
           }
           /**
            * @since 4.0.3 in case of geometry layer with feature with geometry null,
-           * need to set geometry undefined to avoit that geometry is added to item properties
+           * need to set geometry undefined to avoid that geometry is added to item properties
            */
           if (null === item.getGeometry()) {
             item.setGeometry(undefined);


### PR DESCRIPTION
If we try to update a feature of geometry layer but it has no geometry, we get an error

**Before** 

<img width="720" height="112" alt="Screenshot_20251009_122157" src="https://github.com/user-attachments/assets/24159b8b-80d9-49eb-8a2f-da625ed0feaf" />

As we can see below, **geometry: null** is added to properties 

<img width="479" height="580" alt="Screenshot_20251009_122256" src="https://github.com/user-attachments/assets/6023d024-8e86-45b4-b565-f9d3bf1dca1c" />

server return an error because _geometry_ is not a layer editing field

**After**

In case of geometry null, need to set geometry undefined (as in case o a feature of  alphanumerical layer) to avoid that it will be added to feature property

<img width="479" height="580" alt="Screenshot_20251009_122721" src="https://github.com/user-attachments/assets/ce23452e-f793-42fe-8ed2-0191d8e4d770" />
