### PR TITLE
🐛Get an a javascript error if try to split multiple features

### DIFF
--- a/utils/handleSplitFeature.js
+++ b/utils/handleSplitFeature.js
@@ -29,7 +29,6 @@ export async function handleSplitFeature({
   const source                   = layer.getEditingLayer().getSource();
   const layerId                  = layer.getId();
   const oriFeature               = feature.clone();
-  inputs.features                = splittedGeometries.length ? [] : inputs.features;
   const splittedGeometriesLength = splittedGeometries.length;
 
   for (let index = 0; index < splittedGeometriesLength; index++) {


### PR DESCRIPTION
If you try to split multi features

<img width="847" height="825" alt="Screenshot_20260304_115809" src="https://github.com/user-attachments/assets/3b592327-7b04-442b-81bd-066b6358c8ac" />


**Before**

<img width="1567" height="846" alt="Screenshot_20260304_120001" src="https://github.com/user-attachments/assets/217e17a1-f84c-47d6-a683-2178ce8e44f9" />


**After**

<img width="610" height="564" alt="Screenshot_20260304_115842" src="https://github.com/user-attachments/assets/03dce60e-96fd-476d-a3c7-28e59f414cdd" />
